### PR TITLE
kernel: fix disable/enable_interrupts in asm.h

### DIFF
--- a/kernel/include/asm.h
+++ b/kernel/include/asm.h
@@ -9,8 +9,8 @@
 #define halt()                    asm volatile( "cli ; hlt" )
 
 #define interrupts_enabled()         (get_flags() & EFLAGS_IF)
-#define disable_interrupts(flags)    ({save_flags(flags);force_interrupts_on();})
-#define enable_interrupts(flags)     ({save_flags(flags);force_interrupts_off();})
+#define disable_interrupts(flags)    ({save_flags(flags);force_interrupts_off();})
+#define enable_interrupts(flags)     ({save_flags(flags);force_interrupts_on();})
 #define restore_interrupts(flags)    load_flags(flags)
 
 #endif


### PR DESCRIPTION
Signed-off-by: Leo Sartre <sartre.l@email.ecagroup.com>